### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,19 @@ coverage: clean ## generate and view HTML coverage report
 	py.test --cov-report html
 	$(BROWSER) htmlcov/index.html
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: $(COMMON_CONSTRAINTS_TXT)
+	## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q pip-tools
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/dev.txt requirements/base.in requirements/dev.in requirements/quality.in
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in
 	pip-compile --upgrade -o requirements/test.txt requirements/base.in requirements/test.in

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,25 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<4.0
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,4 +9,4 @@
 # linking to it here is good.
 
 # This file contains all common constraints for edx-repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,7 +5,6 @@
 diff-cover                # Changeset diff test coverage
 edx-lint                  # For updating pylintrc
 edx-i18n-tools            # For i18n_tool dummy
-pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 twine                     # Utility for PyPI package uploads

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,8 +16,6 @@ build==0.8.0
     # via -r requirements/quality.in
 certifi==2022.6.15
     # via requests
-cffi==1.15.0
-    # via cryptography
 chardet==4.0.0
     # via diff-cover
 charset-normalizer==2.0.12
@@ -27,15 +25,12 @@ click==8.1.3
     #   click-log
     #   code-annotations
     #   edx-lint
-    #   pip-tools
 click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
 commonmark==0.9.1
     # via rich
-cryptography==37.0.3
-    # via secretstorage
 diff-cover==6.5.0
     # via -r requirements/dev.in
 dill==0.3.5.1
@@ -44,7 +39,7 @@ distlib==0.3.4
     # via virtualenv
 django==3.2.13
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   edx-i18n-tools
 docutils==0.18.1
@@ -69,10 +64,6 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   code-annotations
@@ -94,11 +85,7 @@ path==16.4.0
 pbr==5.9.0
     # via stevedore
 pep517==0.12.0
-    # via
-    #   build
-    #   pip-tools
-pip-tools==6.6.2
-    # via -r requirements/dev.in
+    # via build
 pkginfo==1.8.3
     # via twine
 platformdirs==2.5.2
@@ -115,8 +102,6 @@ py==1.11.0
     # via tox
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==1.1.1
     # via -r requirements/quality.in
 pygments==2.12.0
@@ -160,8 +145,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -207,14 +190,11 @@ virtualenv==20.14.1
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
-    # via
-    #   -r requirements/dev.in
-    #   pip-tools
+    # via -r requirements/dev.in
 wrapt==1.14.1
     # via astroid
 zipp==3.8.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools

--- a/requirements/pip-tools.in
+++ b/requirements/pip-tools.in
@@ -1,0 +1,3 @@
+-c constraints.txt
+
+pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,17 @@
 #
 #    make upgrade
 #
+click==8.1.3
+    # via pip-tools
+pep517==0.12.0
+    # via pip-tools
+pip-tools==6.6.2
+    # via -r requirements/pip-tools.in
+tomli==2.0.1
+    # via pep517
 wheel==0.37.1
-    # via -r requirements/pip.in
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
-    # via -r requirements/pip.in
-setuptools==59.8.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+# pip
+# setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,8 +14,6 @@ build==0.8.0
     # via -r requirements/quality.in
 certifi==2022.6.15
     # via requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via requests
 click==8.1.3
@@ -29,8 +27,6 @@ code-annotations==1.3.0
     # via edx-lint
 commonmark==0.9.1
     # via rich
-cryptography==37.0.3
-    # via secretstorage
 dill==0.3.5.1
     # via pylint
 docutils==0.18.1
@@ -47,10 +43,6 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via code-annotations
 keyring==23.6.0
@@ -73,8 +65,6 @@ platformdirs==2.5.2
     # via pylint
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==1.1.1
     # via -r requirements/quality.in
 pygments==2.12.0
@@ -113,8 +103,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ attrs==21.4.0
 coverage[toml]==6.4.1
     # via pytest-cov
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
 iniconfig==1.1.1
     # via pytest


### PR DESCRIPTION
Added pip-tools requirements file and updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions. For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.