### PR TITLE
feat!: Make help-tokens work with docs.openedx.org

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,15 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[3.0.0] - 2025-03-14
+====================
+
+* Dropped support for edx.readthedocs.io URLs in
+  favor of docs.openedx.org URLs.
+
+  See https://github.com/openedx/edx-documentation/issues/2319
+
+
 [2.4.0] - 2024-03-29
 ====================
 

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,8 @@ Help-tokens reads these Django settings to create URLs:
 * HELP_TOKENS_BOOKS: a dictionary mapping book slugs to URLs.  For example::
 
     HELP_TOKENS_BOOKS = {
-        'learner': 'http://edx.readthedocs.io/projects/learner-guide',
-        'course_author': 'http://edx.readthedocs.io/projects/running-a-course',
+        'learner': 'https://docs.openedx.org/en/latest/learners',
+        'course_author': 'https://docs.openedx.org/en/latest/educators',
     }
 
 * HELP_TOKENS_VERSION: a string used as part of the final URL, to choose the

--- a/help_tokens/__init__.py
+++ b/help_tokens/__init__.py
@@ -4,4 +4,4 @@ Django app for linking to help pages with short tokens.
 
 from .context_processor import context_processor
 
-__version__ = '2.4.0'
+__version__ = '3.0.0'

--- a/help_tokens/core.py
+++ b/help_tokens/core.py
@@ -70,11 +70,11 @@ class HelpUrlExpert:
         lang = getattr(settings, "HELP_TOKENS_LANGUAGE_CODE", None)
         if lang is not None:
             lang = self.get_config_value("locales", lang)
-            url += "/" + lang
+            url = url.replace("/en", "/" + lang)
 
         version = getattr(settings, "HELP_TOKENS_VERSION", None)
         if version is not None:
-            url += "/" + version
+            url = url.replace("/latest", "/" + version)
 
         url += "/" + url_tail
         return url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,9 @@ def book_settings(settings):
     """Set some HELP_TOKENS settings."""
     settings.HELP_TOKENS_INI_FILE = "tests/sample.ini"
     settings.HELP_TOKENS_BOOKS = {
-        'learner': 'http://edx.readthedocs.io/projects/learner-guide',
-        'course_author': 'http://edx.readthedocs.io/projects/running-a-course',
+        'learner': 'https://docs.openedx.org/en/latest/learners',
+        'course_author': 'https://docs.openedx.org/en/latest/educators',
     }
-    settings.HELP_TOKENS_VERSION = "ver"
+    settings.HELP_TOKENS_VERSION = "latest"
     settings.HELP_TOKENS_LANGUAGE_CODE = "en"
     return settings

--- a/tests/test_context_processor.py
+++ b/tests/test_context_processor.py
@@ -11,5 +11,5 @@ from help_tokens import context_processor
 def test_context_processor(book_settings):
     context = context_processor(None)
     actual = context['get_online_help_info']('instructor')['doc_url']
-    expected = "http://edx.readthedocs.io/projects/learner-guide/en/ver/SFD_instructor_dash_help.html"
+    expected = "https://docs.openedx.org/en/latest/learners/SFD_instructor_dash_help.html"
     assert actual == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,29 +27,29 @@ def test_no_token(sample_expert):
 
 
 def test_url_for_token(sample_expert, book_settings):
-    expected = "http://edx.readthedocs.io/projects/learner-guide/en/ver/SFD_instructor_dash_help.html"
+    expected = "https://docs.openedx.org/en/latest/learners/SFD_instructor_dash_help.html"
     assert sample_expert.url_for_token("instructor") == expected
 
 
 def test_no_version(sample_expert, book_settings):
     book_settings.HELP_TOKENS_VERSION = None
-    expected = "http://edx.readthedocs.io/projects/learner-guide/en/SFD_instructor_dash_help.html"
+    expected = "https://docs.openedx.org/en/latest/learners/SFD_instructor_dash_help.html"
     assert sample_expert.url_for_token("instructor") == expected
 
 
 def test_language_code(sample_expert, book_settings):
     book_settings.HELP_TOKENS_LANGUAGE_CODE = "fr_CA"
-    expected = "http://edx.readthedocs.io/projects/learner-guide/fr/ver/SFD_instructor_dash_help.html"
+    expected = "https://docs.openedx.org/fr/latest/learners/SFD_instructor_dash_help.html"
     assert sample_expert.url_for_token("instructor") == expected
 
 
 def test_unknown_language_code(sample_expert, book_settings):
     book_settings.HELP_TOKENS_LANGUAGE_CODE = "xx"
-    expected = "http://edx.readthedocs.io/projects/learner-guide/en/ver/SFD_instructor_dash_help.html"
+    expected = "https://docs.openedx.org/en/latest/learners/SFD_instructor_dash_help.html"
     assert sample_expert.url_for_token("instructor") == expected
 
 
 def test_no_language_code(sample_expert, book_settings):
     book_settings.HELP_TOKENS_LANGUAGE_CODE = None
-    expected = "http://edx.readthedocs.io/projects/learner-guide/ver/SFD_instructor_dash_help.html"
+    expected = "https://docs.openedx.org/en/latest/learners/SFD_instructor_dash_help.html"
     assert sample_expert.url_for_token("instructor") == expected

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,5 +9,5 @@ Tests for the help-tokens urls and views.
 def test_redirect(client, book_settings):
     response = client.get("/instructor")
     assert response.status_code == 302
-    expected = "http://edx.readthedocs.io/projects/learner-guide/en/ver/SFD_instructor_dash_help.html"
+    expected = "https://docs.openedx.org/en/latest/learners/SFD_instructor_dash_help.html"
     assert response['location'] == expected


### PR DESCRIPTION
Ref https://github.com/openedx/edx-documentation/issues/2339

We've migrated the docs to docs.openedx.org. Reconstruct URLs
to work with docs.openedx.org URLs.