### PR TITLE
Drop Python 3.8 & Add Support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.11', '3.12']
         toxenv: [quality, django42, django52, check_keywords]
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.11' && matrix.toxenv=='django52'
+      if: matrix.python-version == '3.12' && matrix.toxenv=='django52'
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -16,7 +16,7 @@ jobs:
        - name: setup python
          uses: actions/setup-python@v5
          with:
-           python-version: 3.11
+           python-version: 3.12
 
        - name: Install pip
          run: pip install -r requirements/pip.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[3.2.0] - 2025-04-21
+====================
+* Added support for Python 3.12
+
 [3.1.0] - 2025-04-09
 ====================
 * Dropped support for Python 3.8 and 3.9

--- a/help_tokens/__init__.py
+++ b/help_tokens/__init__.py
@@ -4,4 +4,4 @@ Django app for linking to help pages with short tokens.
 
 from .context_processor import context_processor
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -26,7 +26,7 @@ filelock==3.18.0
     #   virtualenv
 idna==3.10
     # via requests
-packaging==24.2
+packaging==25.0
     # via
     #   pyproject-api
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,8 +18,6 @@ cachetools==5.5.2
     # via tox
 certifi==2025.1.31
     # via requests
-cffi==1.17.1
-    # via cryptography
 chardet==5.2.0
     # via
     #   diff-cover
@@ -37,11 +35,9 @@ code-annotations==2.3.0
     # via edx-lint
 colorama==0.4.6
     # via tox
-cryptography==44.0.2
-    # via secretstorage
 diff-cover==9.2.4
     # via -r requirements/dev.in
-dill==0.3.9
+dill==0.4.0
     # via pylint
 distlib==0.3.9
     # via virtualenv
@@ -78,10 +74,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   code-annotations
@@ -92,7 +84,7 @@ lxml[html-clean,html_clean]==5.3.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.1
+lxml-html-clean==0.4.2
     # via lxml
 markdown-it-py==3.0.0
     # via rich
@@ -108,13 +100,12 @@ more-itertools==10.6.0
     #   jaraco-functools
 nh3==0.2.21
     # via readme-renderer
-packaging==24.2
+packaging==25.0
     # via
     #   build
     #   pyproject-api
     #   tox
     #   twine
-    #   wheel
 path==16.16.0
     # via edx-i18n-tools
 pbr==6.1.1
@@ -132,8 +123,6 @@ polib==1.2.0
     # via edx-i18n-tools
 pycodestyle==2.13.0
     # via -r requirements/quality.in
-pycparser==2.22
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.19.1
@@ -178,8 +167,6 @@ rfc3986==2.0.0
     # via twine
 rich==14.0.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.17.0
     # via edx-lint
 snowballstemmer==2.2.0
@@ -205,7 +192,7 @@ urllib3==2.2.3
     #   twine
 virtualenv==20.30.0
     # via tox
-wheel==0.46.1
+wheel==0.45.1
     # via -r requirements/dev.in
 zipp==3.21.0
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,17 +8,15 @@ build==1.2.2.post1
     # via pip-tools
 click==8.1.8
     # via pip-tools
-packaging==24.2
-    # via
-    #   build
-    #   wheel
+packaging==25.0
+    # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.46.1
+wheel==0.45.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,15 +4,13 @@
 #
 #    make upgrade
 #
-packaging==24.2
-    # via wheel
-wheel==0.46.1
+wheel==0.45.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/help-tokens/help-tokens/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==78.1.0
+setuptools==79.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,8 +14,6 @@ build==1.2.2.post1
     # via -r requirements/quality.in
 certifi==2025.1.31
     # via requests
-cffi==1.17.1
-    # via cryptography
 charset-normalizer==3.4.1
     # via requests
 click==8.1.8
@@ -27,9 +25,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==2.3.0
     # via edx-lint
-cryptography==44.0.2
-    # via secretstorage
-dill==0.3.9
+dill==0.4.0
     # via pylint
 docutils==0.21.2
     # via readme-renderer
@@ -51,10 +47,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via code-annotations
 keyring==25.6.0
@@ -73,7 +65,7 @@ more-itertools==10.6.0
     #   jaraco-functools
 nh3==0.2.21
     # via readme-renderer
-packaging==24.2
+packaging==25.0
     # via
     #   build
     #   twine
@@ -83,8 +75,6 @@ platformdirs==4.3.7
     # via pylint
 pycodestyle==2.13.0
     # via -r requirements/quality.in
-pycparser==2.22
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.19.1
@@ -124,8 +114,6 @@ rfc3986==2.0.0
     # via twine
 rich==14.0.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.17.0
     # via edx-lint
 snowballstemmer==2.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/test.in
 iniconfig==2.1.0
     # via pytest
-packaging==24.2
+packaging==25.0
     # via pytest
 pluggy==1.5.0
     # via pytest

--- a/setup.py
+++ b/setup.py
@@ -155,5 +155,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311}-django{42, 52}, quality, check_keywords
+envlist = py{311, 312}-django{42, 52}, quality, check_keywords
 
 [pycodestyle]
 exclude = .git,.tox,migrations


### PR DESCRIPTION
- resolves: https://github.com/openedx/help-tokens/issues/227

---
- bump version
- upgrade requirements